### PR TITLE
Addes 'secrets.' prefix to SQL secret example

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ A URI-style database connection string. Flat will use this connection string to 
 > Most connection strings contain an authentication secret like a username and password. GitHub provides an encrypted vault for secrets like these which can be used by the action when it runs. [Create a secret](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) on the repository where the Flat action will run, and use that secret in your workflow.yaml like so:
 >
 > ```
-> sql_connstring: ${{NAME_OF_THE_CREATED_SECRET}}
+> sql_connstring: ${{secrets.NAME_OF_THE_CREATED_SECRET}}
 > ```
 >
 > If you're using the [flat-vscode extension](https://github.com/githubocto/flat-vscode), this is handled for you.


### PR DESCRIPTION
👋 
Thanks for this cool project! 
When I tested out the project and wanted to use secrets, I got fooled by the placeholder value here, and forgot to add the `secrets.*` prefix to my variable. Someone used to Github Actions would probably remember this, but it's easy to forget.
You can decide if this is a good contribution or not 😄 