### PR TITLE
Specify version for denoland/setup-deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
     steps:
       # This step installs Deno, which is a new Javascript runtime that improves on Node. Can be used for an optional postprocessing step
       - name: Setup deno
-        uses: denoland/setup-deno@main
+        uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
       # Check out the repository so it can read the files inside of it and do other operations


### PR DESCRIPTION
denoland/setup-deno@v1 was published recently and is used in the
README.md of the action:
https://github.com/denoland/setup-deno/blob/4a4e59637fa62bd6c086a216c7e4c5b457ea9e79/README.md

We should use it, too.