### PR TITLE
Update docs to use Deno 1.10.x instead of latest v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
       - name: Setup deno
         uses: denoland/setup-deno@main
         with:
-          deno-version: v1.x
+          deno-version: v1.10.x
       # Check out the repository so it can read the files inside of it and do other operations
       - name: Check out repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Deno 1.11 has just been released and it appears to be incompatible with the flat Deno package. Just updating the docs to use `1.10.x` until this is resolved.

#45