### PR TITLE
Add a blank line after the commit message's first

### DIFF
--- a/src/post.ts
+++ b/src/post.ts
@@ -29,7 +29,7 @@ const run = async () => {
   // these should already be staged, in main.ts
   core.info(`Committing "${msg}"`)
   core.debug(meta)
-  await exec('git', ['commit', '-m', msg + '\n' + meta])
+  await exec('git', ['commit', '-m', msg + '\n\n' + meta])
   await exec('git', ['push'])
   core.info(`Pushed!`)
   core.exportVariable('HAS_RUN_POST_JOB', 'true')


### PR DESCRIPTION
From the git man page:
https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-commit.html#_discussion

> Though not required, it’s a good idea to begin the commit message with a
> single short (less than 50 character) line summarizing the change, followed
> by a blank line and then a more thorough description. The text up to the
> first blank line in a commit message is treated as the commit title, and that
> title is used throughout Git.

In my case it means that tig includes the full JSON metadata on one line D: