### PR TITLE
Run action on Node 16 instead of Node 12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ outputs:
   delta_bytes: # size of changed data
     description: The overall number of bytes changed in the output data this run (current size - previous size)
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
   post: 'dist/post/index.js'
 branding:


### PR DESCRIPTION
Closes: #76 

Reason: [Deprecation of Node 12 for GitHub Actions](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)